### PR TITLE
Update ScrollableGraphView.swift

### DIFF
--- a/Classes/ScrollableGraphView.swift
+++ b/Classes/ScrollableGraphView.swift
@@ -1471,7 +1471,7 @@ private class DataPointDrawingLayer: ScrollableGraphViewDrawingLayer {
     }
     
     private func createCircleDataPoint(centre: CGPoint) -> UIBezierPath {
-        return UIBezierPath(arcCenter: centre, radius: dataPointSize, startAngle: 0, endAngle: CGFloat(2.0 * M_PI), clockwise: true)
+        return UIBezierPath(arcCenter: centre, radius: dataPointSize, startAngle: 0, endAngle: CGFloat(2.0 * Double.pi), clockwise: true)
     }
     
     private func createSquareDataPoint(centre: CGPoint) -> UIBezierPath {
@@ -1992,6 +1992,6 @@ private struct Easings {
     
     static let easeOutElastic = { (t: Double) -> Double in
         var p = 0.3;
-        return pow(2,-10*t) * sin((t-p/4)*(2*M_PI)/p) + 1;
+        return pow(2,-10*t) * sin((t-p/4)*(2*Double.pi)/p) + 1;
     }
 }


### PR DESCRIPTION
Update for Swift 3.1
`M_PI` is depreciated. Use `Double.pi` instead