### PR TITLE
Removed extra space between value and unit in Reference Label

### DIFF
--- a/Classes/Drawing/ReferenceLineDrawingView.swift
+++ b/Classes/Drawing/ReferenceLineDrawingView.swift
@@ -26,7 +26,7 @@ internal class ReferenceLineDrawingView : UIView {
     private var units: String {
         get {
             if let units = self.settings.referenceLineUnits {
-                return " \(units)"
+                return "\(units)"
             } else {
                 return ""
             }


### PR DESCRIPTION
A space is already added in createReferenceLineFrom(from lineStart: CGPoint, to lineEnd: CGPoint, in path: UIBezierPath), which means currently there are 2 spaces between value and unit.