### PR TITLE
changed setting to use Swift 4.2

### DIFF
--- a/carthage/ScrollableGraphView/ScrollableGraphView.xcodeproj/project.pbxproj
+++ b/carthage/ScrollableGraphView/ScrollableGraphView.xcodeproj/project.pbxproj
@@ -389,7 +389,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = SGV.ScrollableGraphView;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -407,7 +407,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = SGV.ScrollableGraphView;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
I was unable to compile version 4.0.6 on XCode 10 because of the Swift language version in the settings was still set to Swift 4. 

This PR changed the settings to Swift 4.2. 

