### PR TITLE
Required constructors added to Drawing Layers.

### DIFF
--- a/Classes/Drawing/BarDrawingLayer.swift
+++ b/Classes/Drawing/BarDrawingLayer.swift
@@ -8,6 +8,10 @@ internal class BarDrawingLayer: ScrollableGraphViewDrawingLayer {
     private var barWidth: CGFloat = 4
     private var shouldRoundCorners = false
     
+    override init(layer: Any) {
+        super.init(layer: layer)
+    }
+    
     init(frame: CGRect, barWidth: CGFloat, barColor: UIColor, barLineWidth: CGFloat, barLineColor: UIColor, shouldRoundCorners: Bool) {
         super.init(viewportWidth: frame.size.width, viewportHeight: frame.size.height)
         

--- a/Classes/Drawing/DotDrawingLayer.swift
+++ b/Classes/Drawing/DotDrawingLayer.swift
@@ -9,6 +9,10 @@ internal class DotDrawingLayer: ScrollableGraphViewDrawingLayer {
     
     private var customDataPointPath: ((_ centre: CGPoint) -> UIBezierPath)?
     
+    override init(layer: Any) {
+        super.init(layer: layer)
+    }
+    
     init(frame: CGRect, fillColor: UIColor, dataPointType: ScrollableGraphViewDataPointType, dataPointSize: CGFloat, customDataPointPath: ((_ centre: CGPoint) -> UIBezierPath)? = nil) {
         
         self.dataPointType = dataPointType

--- a/Classes/Drawing/FillDrawingLayer.swift
+++ b/Classes/Drawing/FillDrawingLayer.swift
@@ -5,7 +5,11 @@ internal class FillDrawingLayer : ScrollableGraphViewDrawingLayer {
     
     // Fills are only used with lineplots and we need
     // to know what the line looks like.
-    private var lineDrawingLayer: LineDrawingLayer
+    private var lineDrawingLayer: LineDrawingLayer!
+    
+    override init(layer: Any) {
+        super.init(layer: layer)
+    }
     
     init(frame: CGRect, fillColor: UIColor, lineDrawingLayer: LineDrawingLayer) {
         

--- a/Classes/Drawing/GradientDrawingLayer.swift
+++ b/Classes/Drawing/GradientDrawingLayer.swift
@@ -65,10 +65,12 @@ internal class GradientDrawingLayer : ScrollableGraphViewDrawingLayer {
         let endRadius: CGFloat = self.bounds.width
         
         switch(gradientType) {
-        case .linear:
+        case .linear?:
             ctx.drawLinearGradient(gradient!, start: topCentre, end: bottomCentre, options: .drawsAfterEndLocation)
-        case .radial:
+        case .radial?:
             ctx.drawRadialGradient(gradient!, startCenter: topCentre, startRadius: startRadius, endCenter: topCentre, endRadius: endRadius, options: .drawsAfterEndLocation)
+        default:
+            fatalError("Unknown type of gradient.")
         }
     }
 }

--- a/Classes/Drawing/GradientDrawingLayer.swift
+++ b/Classes/Drawing/GradientDrawingLayer.swift
@@ -3,13 +3,13 @@ import UIKit
 
 internal class GradientDrawingLayer : ScrollableGraphViewDrawingLayer {
     
-    private var startColor: UIColor
-    private var endColor: UIColor
-    private var gradientType: ScrollableGraphViewGradientType
+    private var startColor: UIColor!
+    private var endColor: UIColor!
+    private var gradientType: ScrollableGraphViewGradientType!
     
     // Gradient fills are only used with lineplots and we need 
     // to know what the line looks like.
-    private var lineDrawingLayer: LineDrawingLayer
+    private var lineDrawingLayer: LineDrawingLayer!
     
     lazy private var gradientMask: CAShapeLayer = ({
         let mask = CAShapeLayer()
@@ -20,6 +20,10 @@ internal class GradientDrawingLayer : ScrollableGraphViewDrawingLayer {
         
         return mask
     })()
+	
+    override init(layer: Any) {
+        super.init(layer: layer)
+    }
     
     init(frame: CGRect, startColor: UIColor, endColor: UIColor, gradientType: ScrollableGraphViewGradientType, lineJoin: String = convertFromCAShapeLayerLineJoin(CAShapeLayerLineJoin.round), lineDrawingLayer: LineDrawingLayer) {
         self.startColor = startColor

--- a/Classes/Drawing/LineDrawingLayer.swift
+++ b/Classes/Drawing/LineDrawingLayer.swift
@@ -5,9 +5,13 @@ internal class LineDrawingLayer : ScrollableGraphViewDrawingLayer {
     
     private var currentLinePath = UIBezierPath()
     
-    private var lineStyle: ScrollableGraphViewLineStyle
-    private var shouldFill: Bool
-    private var lineCurviness: CGFloat
+    private var lineStyle: ScrollableGraphViewLineStyle!
+    private var shouldFill: Bool!
+    private var lineCurviness: CGFloat!
+	
+    override init(layer: Any) {
+        super.init(layer: layer)
+    }
     
     init(frame: CGRect, lineWidth: CGFloat, lineColor: UIColor, lineStyle: ScrollableGraphViewLineStyle, lineJoin: String, lineCap: String, shouldFill: Bool, lineCurviness: CGFloat) {
         

--- a/Classes/Drawing/ScrollableGraphViewDrawingLayer.swift
+++ b/Classes/Drawing/ScrollableGraphViewDrawingLayer.swift
@@ -17,6 +17,10 @@ internal class ScrollableGraphViewDrawingLayer : CAShapeLayer {
     
     var active = true
     
+    override init(layer: Any) {
+        super.init()
+    }
+    
     init(viewportWidth: CGFloat, viewportHeight: CGFloat, offset: CGFloat = 0) {
         super.init()
         


### PR DESCRIPTION
A bug fixed which occurres while debugging UI through Xcode. There was a message in log window "use of unimplemented initializer 'init(layer:)' for class ...DrawingLayer". 

It was preventing me from seeing UI objects, so I couldn't do a debug. I added missing overridden constructors init(layer:), So, that bug gone away. 

Works well right now. ✊🏼