### PR TITLE
Removed public from the extension declaration. This has been deprecated in Swift 5.

### DIFF
--- a/Classes/ScrollableGraphView.swift
+++ b/Classes/ScrollableGraphView.swift
@@ -981,7 +981,7 @@ fileprivate class SGVQueue<T> {
 
 // We have to be our own data source for interface builder.
 #if TARGET_INTERFACE_BUILDER
-public extension ScrollableGraphView : ScrollableGraphViewDataSource {
+extension ScrollableGraphView : ScrollableGraphViewDataSource {
     
     var numberOfDisplayItems: Int {
         get {


### PR DESCRIPTION
The `public` declaration generated alerts in Swift 4.2 that warned that `public` would become deprecated in future releases. Now in Swift 5.0, it is officially deprecated.